### PR TITLE
Fix incorrect event listener removal

### DIFF
--- a/js/scene/menuScene.js
+++ b/js/scene/menuScene.js
@@ -17,13 +17,13 @@ menuScene.initialize = () => {
         complete: () => {
             // event to check in Mobile/Desktop
             ['touchend', 'click'].forEach(evt => {
-                elementManager.startButton.addEventListener(evt, function() {
+                const handler = function () {
                     that.isCompleted = true
                     elementManager.startButton.style.display = 'none'
-                    
-                    var clone = elementManager.startButton.cloneNode(true)
-                    elementManager.startButton.removeEventListener(evt, this)
-                })
+
+                    elementManager.startButton.removeEventListener(evt, handler)
+                }
+                elementManager.startButton.addEventListener(evt, handler)
             })
         }
     })


### PR DESCRIPTION
## Summary
- fix menu scene event listener so it can be removed properly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683ff12425dc8327868df755cfd8c367