### PR TITLE
Update dependencies to secure versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5070,9 +5070,9 @@
       }
     },
     "yargs-parser": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.0.0.tgz",
-      "integrity": "sha512-8eblPHTL7ZWRkyjIZJjnGf+TijiKJSwA24svzLRVvtgoi/RZiKa9fFQTrlx0OKLnyHSdt/enrdadji6WFfESVA=="
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,11 +19,10 @@
     "gulp-babel-minify": "^0.5.1",
     "gulp-concat": "^2.6.1",
     "gulp-pug": "^5.0.0",
-    "gulp-stylus": "^2.7.0",
-    "yargs-parser": ">=13.1.2"
+    "gulp-stylus": "^2.7.0"
   },
   "dependencies": {
-    "express": "^4.17.1",
-    "yargs-parser": ">=13.1.2"
+    "express": "^4.21.2",
+    "yargs-parser": "^20.2.9"
   }
 }


### PR DESCRIPTION
## Summary
- update `express` and `yargs-parser` versions
- remove duplicate `yargs-parser` dev dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683ffacddd7883278603ea9acf724e78